### PR TITLE
updated .gitattributes to mask non-domain langs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -61,3 +61,14 @@
 #*.PDF   diff=astextplain
 #*.rtf   diff=astextplain
 #*.RTF   diff=astextplain
+
+###############################################################################
+# mask certain file types from linguist to ensure the proper
+# language emphasis is supported in GraphQL API searches
+###############################################################################
+
+*.css linguist-detectable=false
+*.scss linguist-detectable=false
+*.js linguist-detectable=false
+*.html linguist-detectable=false
+*.javascript linguist-detectable=false


### PR DESCRIPTION
This is a quick house-keeping sweep to ensure that F# shows as the primary language when queried via the GitHub GraphQL API. See attached screen shots for before and after.

![Screenshot 2021-03-05 134503](https://user-images.githubusercontent.com/8174976/110177095-454c9280-7db9-11eb-88b0-d98927614f3e.png)
![Screenshot 2021-03-05 134539](https://user-images.githubusercontent.com/8174976/110177098-4978b000-7db9-11eb-8aab-68236bfde2f5.png)
